### PR TITLE
merge: develop <- feature/course-domain-entity

### DIFF
--- a/lms/build.gradle
+++ b/lms/build.gradle
@@ -38,6 +38,11 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1'
+    implementation 'org.mapstruct:mapstruct:1.6.3'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/lms/src/main/java/com/example/lms/domain/content/entity/Content.java
+++ b/lms/src/main/java/com/example/lms/domain/content/entity/Content.java
@@ -12,9 +12,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "content")
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
-@Builder
 public class Content extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,4 +31,21 @@ public class Content extends BaseTimeEntity {
 
     @Column(name = "file_url", length = 300, nullable = false)
     private String fileUrl;
+
+    @Builder
+    public Content(Course course, String fileType, String fileName, String fileUrl) {
+        this.course = course;
+        this.fileType = fileType;
+        this.fileName = fileName;
+        this.fileUrl = fileUrl;
+    }
+
+    public static Content of(Course course, String fileType, String fileName, String fileUrl) {
+        return Content.builder()
+                .course(course)
+                .fileType(fileType)
+                .fileName(fileName)
+                .fileUrl(fileUrl)
+                .build();
+    }
 }

--- a/lms/src/main/java/com/example/lms/domain/content/entity/Content.java
+++ b/lms/src/main/java/com/example/lms/domain/content/entity/Content.java
@@ -1,0 +1,36 @@
+package com.example.lms.domain.content.entity;
+
+import com.example.lms.common.base.BaseTimeEntity;
+import com.example.lms.domain.course.entity.Course;
+import io.lettuce.core.dynamic.annotation.CommandNaming;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "content")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class Content extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "content_id")
+    private Long contentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    @Column(name = "file_type", length = 100, nullable = false)
+    private String fileType;
+
+    @Column(name = "file_name", length = 100, nullable = false)
+    private String fileName;
+
+    @Column(name = "file_url", length = 300, nullable = false)
+    private String fileUrl;
+}

--- a/lms/src/main/java/com/example/lms/domain/course/dto/request/CourseCreateRequestDto.java
+++ b/lms/src/main/java/com/example/lms/domain/course/dto/request/CourseCreateRequestDto.java
@@ -1,0 +1,34 @@
+package com.example.lms.domain.course.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CourseCreateRequestDto {
+
+    @NotBlank(message = "과정 제목은 필수 입력값입니다.")
+    @Size(min = 1, max = 50, message = "과정 제목은 1자 이상 50자 이하로 입력해주세요.")
+    private String courseTitle;
+
+    @NotBlank(message = "과정 설명은 필수 입력값입니다.")
+    private String courseDescription;
+
+    @NotNull(message = "과정 시작일은 필수 입력값입니다.")
+    private LocalDate startDate;
+
+    @NotNull(message = "과정 종료일은 필수 입력값입니다.")
+    private LocalDate endDate;
+
+    @Min(value = 0, message = "수강 정원은 0명 이상이어야 합니다.")
+    private int courseCapacity;
+}

--- a/lms/src/main/java/com/example/lms/domain/course/dto/request/CourseCreateRequestDto.java
+++ b/lms/src/main/java/com/example/lms/domain/course/dto/request/CourseCreateRequestDto.java
@@ -30,5 +30,8 @@ public class CourseCreateRequestDto {
     private LocalDate endDate;
 
     @Min(value = 0, message = "수강 정원은 0명 이상이어야 합니다.")
-    private int courseCapacity;
+    private Integer courseCapacity;
+
+    @NotNull(message = "강사 ID는 필수 입력값입니다.")
+    private Long instructorId;
 }

--- a/lms/src/main/java/com/example/lms/domain/course/dto/request/CourseUpdateRequestDto.java
+++ b/lms/src/main/java/com/example/lms/domain/course/dto/request/CourseUpdateRequestDto.java
@@ -30,5 +30,5 @@ public class CourseUpdateRequestDto {
     private LocalDate endDate;
 
     @Min(value = 0, message = "수강 정원은 0명 이상이어야 합니다.")
-    private int courseCapacity;
+    private Integer courseCapacity;
 }

--- a/lms/src/main/java/com/example/lms/domain/course/dto/request/CourseUpdateRequestDto.java
+++ b/lms/src/main/java/com/example/lms/domain/course/dto/request/CourseUpdateRequestDto.java
@@ -1,0 +1,34 @@
+package com.example.lms.domain.course.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CourseUpdateRequestDto {
+    @NotBlank(message = "과정 제목은 필수 입력값입니다.")
+    @Size(min = 1, max = 50, message = "과정 제목은 1자 이상 50자 이하로 입력해주세요.")
+    private String courseTitle;
+
+    @NotBlank(message = "과정 설명은 필수 입력값입니다.")
+    private String courseDescription;
+
+    @NotNull(message = "과정 시작일은 필수 입력값입니다.")
+    private LocalDate startDate;
+
+    @NotNull(message = "과정 종료일은 필수 입력값입니다.")
+    private LocalDate endDate;
+
+    @Min(value = 0, message = "수강 정원은 0명 이상이어야 합니다.")
+    private int courseCapacity;
+}

--- a/lms/src/main/java/com/example/lms/domain/course/dto/response/CourseResponseDto.java
+++ b/lms/src/main/java/com/example/lms/domain/course/dto/response/CourseResponseDto.java
@@ -1,0 +1,19 @@
+package com.example.lms.domain.course.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CourseResponseDto {
+    private Long courseId;
+    private String courseTitle;
+    private String instructorName;
+    private int courseStudents;
+    private String startDate;
+    private String endDate;
+}

--- a/lms/src/main/java/com/example/lms/domain/course/dto/response/CourseResponseDto.java
+++ b/lms/src/main/java/com/example/lms/domain/course/dto/response/CourseResponseDto.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -12,8 +14,9 @@ import lombok.NoArgsConstructor;
 public class CourseResponseDto {
     private Long courseId;
     private String courseTitle;
+    private String courseDescription;
     private String instructorName;
-    private int courseStudents;
-    private String startDate;
-    private String endDate;
+    private Integer courseStudents;
+    private LocalDate startDate;
+    private LocalDate endDate;
 }

--- a/lms/src/main/java/com/example/lms/domain/course/entity/Course.java
+++ b/lms/src/main/java/com/example/lms/domain/course/entity/Course.java
@@ -1,20 +1,22 @@
 package com.example.lms.domain.course.entity;
 
 import com.example.lms.common.base.BaseTimeEntity;
+import com.example.lms.domain.content.entity.Content;
+import com.example.lms.domain.instructor.entity.Instructor;
+import com.example.lms.domain.lecture.entity.Lecture;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name="course")
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class Course extends BaseTimeEntity {
 
     @Id
@@ -35,5 +37,45 @@ public class Course extends BaseTimeEntity {
     private LocalDate endDate;
 
     @Column(name = "course_capacity", nullable = false)
-    private int courseCapacity;
+    private Integer courseCapacity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "instructor_id", nullable = false)
+    private Instructor instructor;
+
+    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Lecture> lectures = new ArrayList<>();
+
+    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Content> contents = new ArrayList<>();
+
+
+    /**
+     * 등록 정보 (OneToMany 관계)
+     *
+     * @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+     * private List<Registration> registrations = new ArrayList<>();
+     */
+
+    @Builder
+    public Course(Long courseId, String courseTitle, String courseDescription, LocalDate startDate, LocalDate endDate, int courseCapacity, Instructor instructor) {
+        this.courseId = courseId;
+        this.courseTitle = courseTitle;
+        this.courseDescription = courseDescription;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.courseCapacity = courseCapacity;
+        this.instructor = instructor;
+    }
+
+    public static Course of(String courseTitle, String courseDescription, LocalDate startDate, LocalDate endDate, int courseCapacity, Instructor instructor) {
+        return Course.builder()
+                .courseTitle(courseTitle)
+                .courseDescription(courseDescription)
+                .startDate(startDate)
+                .endDate(endDate)
+                .courseCapacity(courseCapacity)
+                .instructor(instructor)
+                .build();
+    }
 }

--- a/lms/src/main/java/com/example/lms/domain/course/entity/Course.java
+++ b/lms/src/main/java/com/example/lms/domain/course/entity/Course.java
@@ -1,0 +1,39 @@
+package com.example.lms.domain.course.entity;
+
+import com.example.lms.common.base.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name="course")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Course extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "course_id")
+    private Long courseId;
+
+    @Column(name = "course_title", length = 50, nullable = false)
+    private String courseTitle;
+
+    @Column(name = "course_description", columnDefinition = "TEXT")
+    private String courseDescription;
+
+    @Column(name = "course_start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "course_end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "course_capacity", nullable = false)
+    private int courseCapacity;
+}

--- a/lms/src/main/java/com/example/lms/domain/course/mapper/CourseMapper.java
+++ b/lms/src/main/java/com/example/lms/domain/course/mapper/CourseMapper.java
@@ -1,0 +1,22 @@
+package com.example.lms.domain.course.mapper;
+
+import com.example.lms.domain.course.dto.request.CourseCreateRequestDto;
+import com.example.lms.domain.course.dto.response.CourseResponseDto;
+import com.example.lms.domain.course.entity.Course;
+import com.example.lms.domain.instructor.entity.Instructor;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface CourseMapper {
+
+
+    @Mapping(target = "courseId", ignore = true)
+    Course toEntity(CourseCreateRequestDto dto, Instructor instructor);
+
+
+    @Mapping(target = "instructorName", source = "instructor.name")
+//    @Mapping(target = "courseStudents", expression = "java(course.getRegistrations().size())")  // 수강생 수 계산
+    @Mapping(target = "courseStudents", constant = "0")
+    CourseResponseDto toResponseDto(Course course);
+}

--- a/lms/src/main/java/com/example/lms/domain/course/repository/CourseRepository.java
+++ b/lms/src/main/java/com/example/lms/domain/course/repository/CourseRepository.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 public interface CourseRepository extends JpaRepository<Course, Long> {
     List<Course> findByInstructor_Id(Long instructorId);
 }

--- a/lms/src/main/java/com/example/lms/domain/course/repository/CourseRepository.java
+++ b/lms/src/main/java/com/example/lms/domain/course/repository/CourseRepository.java
@@ -1,9 +1,12 @@
-package com.example.lms.domain.course.respository;
+package com.example.lms.domain.course.repository;
 
 import com.example.lms.domain.course.entity.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CourseRepository extends JpaRepository<Course, Long> {
+    List<Course> findByInstructor_Id(Long instructorId);
 }

--- a/lms/src/main/java/com/example/lms/domain/course/respository/CourseRepository.java
+++ b/lms/src/main/java/com/example/lms/domain/course/respository/CourseRepository.java
@@ -1,0 +1,9 @@
+package com.example.lms.domain.course.respository;
+
+import com.example.lms.domain.course.entity.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CourseRepository extends JpaRepository<Course, Long> {
+}

--- a/lms/src/main/java/com/example/lms/domain/course/service/CourseService.java
+++ b/lms/src/main/java/com/example/lms/domain/course/service/CourseService.java
@@ -1,0 +1,47 @@
+package com.example.lms.domain.course.service;
+
+import com.example.lms.domain.course.dto.request.CourseCreateRequestDto;
+import com.example.lms.domain.course.dto.response.CourseResponseDto;
+import com.example.lms.domain.course.entity.Course;
+import com.example.lms.domain.course.mapper.CourseMapper;
+import com.example.lms.domain.course.repository.CourseRepository;
+import com.example.lms.domain.instructor.entity.Instructor;
+import com.example.lms.domain.instructor.repository.InstructorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class CourseService {
+
+    private final CourseRepository courseRepository;
+    private final InstructorRepository instructorRepository;
+    private final CourseMapper courseMapper;
+
+    @Transactional
+    public CourseResponseDto createCourse(CourseCreateRequestDto requestDto) {
+        Instructor instructor = instructorRepository.findById(requestDto.getInstructorId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강사입니다."));
+
+        Course course = courseMapper.toEntity(requestDto, instructor);
+        Course savedCourse = courseRepository.save(course);
+
+        return courseMapper.toResponseDto(savedCourse);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CourseResponseDto> getAllCourses(Long instructorId) {
+        List<Course> courses = (instructorId == null)
+                ? courseRepository.findAll()
+                : courseRepository.findByInstructor_Id(instructorId);
+
+        return courses.stream()
+                .map(courseMapper::toResponseDto)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/lms/src/main/java/com/example/lms/domain/lecture/entity/Lecture.java
+++ b/lms/src/main/java/com/example/lms/domain/lecture/entity/Lecture.java
@@ -1,0 +1,41 @@
+package com.example.lms.domain.lecture.entity;
+
+import com.example.lms.common.base.BaseTimeEntity;
+import com.example.lms.domain.course.entity.Course;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "lecture")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Lecture extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "lecture_id")
+    private Long lectureId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    @Column(name = "lecture_title", length = 50, nullable = false)
+    private String lectureTitle;
+
+    @Column(name = "lecture_description", columnDefinition = "TEXT")
+    private String lectureDescription;
+
+    @Column(name = "lecture_url", length = 300, nullable = false)
+    private String lectureUrl;
+
+    @Column(name = "lecture_time", nullable = false)
+    private LocalTime lectureTime;
+}

--- a/lms/src/main/java/com/example/lms/domain/lecture/entity/Lecture.java
+++ b/lms/src/main/java/com/example/lms/domain/lecture/entity/Lecture.java
@@ -14,8 +14,6 @@ import java.time.LocalTime;
 @Table(name = "lecture")
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class Lecture extends BaseTimeEntity {
 
     @Id
@@ -38,4 +36,23 @@ public class Lecture extends BaseTimeEntity {
 
     @Column(name = "lecture_time", nullable = false)
     private LocalTime lectureTime;
+
+    @Builder
+    public Lecture(Course course, String lectureTitle, String lectureDescription, String lectureUrl, LocalTime lectureTime) {
+        this.course = course;
+        this.lectureTitle = lectureTitle;
+        this.lectureDescription = lectureDescription;
+        this.lectureUrl = lectureUrl;
+        this.lectureTime = lectureTime;
+    }
+
+    public static Lecture of(Course course, String lectureTitle, String lectureDescription, String lectureUrl, LocalTime lectureTime) {
+        return Lecture.builder()
+                .course(course)
+                .lectureTitle(lectureTitle)
+                .lectureDescription(lectureDescription)
+                .lectureUrl(lectureUrl)
+                .lectureTime(lectureTime)
+                .build();
+    }
 }

--- a/lms/src/test/java/com/example/lms/common/fixture/CourseFixture.java
+++ b/lms/src/test/java/com/example/lms/common/fixture/CourseFixture.java
@@ -1,0 +1,73 @@
+package com.example.lms.common.fixture;
+
+import com.example.lms.domain.course.dto.request.CourseCreateRequestDto;
+import com.example.lms.domain.course.dto.response.CourseResponseDto;
+import com.example.lms.domain.course.entity.Course;
+import com.example.lms.domain.instructor.entity.Instructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public enum CourseFixture {
+    COURSE_FIXTURE_1(
+            "Java Spring Boot Course",
+            "스프링 부트의 기초를 학습하고 직접 프로젝트를 진행해보는 효율적인 강의입니다.",
+            LocalDate.of(2025, 1, 23),
+            LocalDate.of(2025, 3, 4),
+            30),
+    COURSE_FIXTURE_2(
+            "Data Structures and Algorithms",
+            "자료구와 알고리즘에 대해서 꼼꼼하게 학습하는 강의입니다.",
+            LocalDate.of(2025, 2, 25),
+            LocalDate.of(2025, 4, 3),
+            50);
+
+    private final String courseTitle;
+    private final String courseDescription;
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+    private final Integer courseCapacity;
+
+    CourseFixture(String courseTitle, String courseDescription, LocalDate startDate, LocalDate endDate, int courseCapacity) {
+        this.courseTitle = courseTitle;
+        this.courseDescription = courseDescription;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.courseCapacity = courseCapacity;
+    }
+
+    public Course createCourse(Instructor instructor) {
+        return Course.builder()
+                .courseTitle(courseTitle)
+                .courseDescription(courseDescription)
+                .startDate(startDate)
+                .endDate(endDate)
+                .courseCapacity(courseCapacity)
+                .instructor(instructor)
+                .build();
+    }
+
+    public CourseCreateRequestDto toCreateRequestDto(Long instructorId) {
+        return CourseCreateRequestDto.builder()
+                .courseTitle(courseTitle)
+                .courseDescription(courseDescription)
+                .startDate(startDate)
+                .endDate(endDate)
+                .courseCapacity(courseCapacity)
+                .instructorId(instructorId)
+                .build();
+    }
+
+    public CourseResponseDto toResponseDto(Long courseId, String instructorName) {
+        return CourseResponseDto.builder()
+                .courseId(courseId)
+                .courseTitle(courseTitle)
+                .courseDescription(courseDescription)
+                .startDate(startDate)
+                .endDate(endDate)
+                .instructorName(instructorName)
+                .courseStudents(0) // MapStruct에서 constant 설정
+                .build();
+    }
+}

--- a/lms/src/test/java/com/example/lms/domain/course/mapper/CourseMapperTest.java
+++ b/lms/src/test/java/com/example/lms/domain/course/mapper/CourseMapperTest.java
@@ -1,0 +1,53 @@
+package com.example.lms.domain.course.mapper;
+
+import com.example.lms.common.fixture.CourseFixture;
+import com.example.lms.common.fixture.InstructorFixture;
+import com.example.lms.domain.course.dto.request.CourseCreateRequestDto;
+import com.example.lms.domain.course.dto.response.CourseResponseDto;
+import com.example.lms.domain.course.entity.Course;
+import com.example.lms.domain.instructor.entity.Instructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CourseMapperTest {
+    private final CourseMapper courseMapper = Mappers.getMapper(CourseMapper.class);
+
+    @Test
+    @DisplayName("CourseCreateRequestDto를 Course Entity로 변환합니다.")
+    void toEntityTest() {
+        // given
+        Instructor instructor = InstructorFixture.INSTRUCTOR_FIXTURE_1.createInstructor();
+        CourseFixture courseFixture = CourseFixture.COURSE_FIXTURE_1;
+        CourseCreateRequestDto requestDto = courseFixture.toCreateRequestDto(1L);
+
+        // when
+        Course course = courseMapper.toEntity(requestDto, instructor);
+
+        // then
+        assertThat(course.getCourseTitle()).isEqualTo(courseFixture.getCourseTitle());
+        assertThat(course.getCourseDescription()).isEqualTo(courseFixture.getCourseDescription());
+        assertThat(course.getStartDate()).isEqualTo(courseFixture.getStartDate());
+        assertThat(course.getEndDate()).isEqualTo(courseFixture.getEndDate());
+        assertThat(course.getInstructor().getName()).isEqualTo(instructor.getName());
+        assertThat(course.getCourseId()).isNull(); // courseId는 매핑에서 ignore 설정
+    }
+
+    @Test
+    @DisplayName("Course Entity를 CourseResponseDto로 변환합니다.")
+    void toResponseDtoTest() {
+        // given
+        Instructor instructor = InstructorFixture.INSTRUCTOR_FIXTURE_1.createInstructor();
+        CourseFixture courseFixture = CourseFixture.COURSE_FIXTURE_2;
+        Course course = courseFixture.createCourse(instructor);
+
+        // when
+        CourseResponseDto responseDto = courseMapper.toResponseDto(course);
+
+        // then
+        assertThat(responseDto.getCourseTitle()).isEqualTo(courseFixture.getCourseTitle());
+        assertThat(responseDto.getInstructorName()).isEqualTo(instructor.getName());
+        assertThat(responseDto.getCourseStudents()).isEqualTo(0); // constant 설정된 값
+    }
+}

--- a/lms/src/test/java/com/example/lms/domain/course/service/CourseServiceTest.java
+++ b/lms/src/test/java/com/example/lms/domain/course/service/CourseServiceTest.java
@@ -1,0 +1,151 @@
+package com.example.lms.domain.course.service;
+
+
+import com.example.lms.common.fixture.CourseFixture;
+import com.example.lms.common.fixture.InstructorFixture;
+import com.example.lms.domain.course.dto.request.CourseCreateRequestDto;
+import com.example.lms.domain.course.dto.response.CourseResponseDto;
+import com.example.lms.domain.course.entity.Course;
+import com.example.lms.domain.course.mapper.CourseMapper;
+import com.example.lms.domain.course.repository.CourseRepository;
+import com.example.lms.domain.instructor.entity.Instructor;
+import com.example.lms.domain.instructor.repository.InstructorRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CourseServiceTest {
+    @Mock
+    private CourseRepository courseRepository;
+
+    @Mock
+    private InstructorRepository instructorRepository;
+
+    @Mock
+    private CourseMapper courseMapper;
+
+    @InjectMocks
+    private CourseService courseService;
+
+    private Instructor instructor;
+    private Instructor instructor2;
+    private CourseFixture courseFixture;
+    private CourseFixture courseFixture2;
+
+    @BeforeEach
+    void setUp() {
+        instructor = InstructorFixture.INSTRUCTOR_FIXTURE_1.createInstructor();
+        instructor2 = InstructorFixture.INSTRUCTOR_FIXTURE_2.createInstructor();
+        courseFixture = CourseFixture.COURSE_FIXTURE_1;
+        courseFixture2 = CourseFixture.COURSE_FIXTURE_2;
+    }
+
+    @Test
+    @DisplayName("강의를 생성할 때 올바른 엔티티가 저장되고 응답 객체가 반환됩니다.")
+    void createCourse_success() {
+        // given
+        CourseCreateRequestDto requestDto = courseFixture.toCreateRequestDto(1L);
+        Course course = courseFixture.createCourse(instructor);
+        CourseResponseDto responseDto = courseFixture.toResponseDto(1L, instructor.getName());
+
+        when(instructorRepository.findById(1L)).thenReturn(Optional.of(instructor));
+        when(courseMapper.toEntity(requestDto, instructor)).thenReturn(course);
+        when(courseRepository.save(course)).thenReturn(course);
+        when(courseMapper.toResponseDto(course)).thenReturn(responseDto);
+
+        // when
+        CourseResponseDto result = courseService.createCourse(requestDto);
+
+        // then
+        assertSoftly((softly) -> {
+            softly.assertThat(result.getCourseTitle()).isEqualTo(courseFixture.getCourseTitle());
+            softly.assertThat(result.getCourseStudents()).isEqualTo(0);
+            softly.assertThat(result.getStartDate()).isEqualTo(courseFixture.getStartDate());
+            softly.assertThat(result.getEndDate()).isEqualTo(courseFixture.getEndDate());
+            softly.assertThat(result.getCourseDescription()).isEqualTo(courseFixture.getCourseDescription());
+            softly.assertThat(result.getInstructorName()).isEqualTo(instructor.getName());
+        });
+        verify(courseRepository, times(1)).save(course);
+    }
+
+    @Test
+    @DisplayName("강사가 존재하지 않을 때 예외를 발생시킵니다.")
+    void createCourse_instructorNotFound_throwsException() {
+        // given
+        CourseCreateRequestDto requestDto = courseFixture.toCreateRequestDto(1L);
+        when(instructorRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> courseService.createCourse(requestDto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("존재하지 않는 강사입니다.");
+        verify(courseRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("모든 강의 리스트를 조회할 수 있습니다.")
+    void getAllCourses_success() {
+        // given
+        Course course1 = courseFixture.createCourse(instructor);
+        Course course2 = courseFixture2.createCourse(instructor2);
+
+        CourseResponseDto responseDto1 = courseFixture.toResponseDto(1L, instructor.getName());
+        CourseResponseDto responseDto2 = courseFixture2.toResponseDto(2L, instructor2.getName());
+
+        when(courseRepository.findAll()).thenReturn(List.of(course1, course2));
+        when(courseMapper.toResponseDto(course1)).thenReturn(responseDto1);
+        when(courseMapper.toResponseDto(course2)).thenReturn(responseDto2);
+
+        // when
+        List<CourseResponseDto> courses = courseService.getAllCourses(null);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(courses).hasSize(2);
+            softly.assertThat(courses.get(0).getCourseTitle()).isEqualTo(courseFixture.getCourseTitle());
+            softly.assertThat(courses.get(1).getCourseTitle()).isEqualTo(courseFixture2.getCourseTitle());
+            softly.assertThat(courses.get(0).getInstructorName()).isEqualTo(instructor.getName());
+            softly.assertThat(courses.get(1).getInstructorName()).isEqualTo(instructor2.getName());
+        });
+        verify(courseRepository, times(1)).findAll();
+    }
+
+    @Test
+    @DisplayName("특정 강사의 강의 리스트를 조회할 수 있습니다.")
+    void getAllCoursesByInstructor_success() {
+        // given
+        Course course1 = courseFixture.createCourse(instructor);
+        Course course2 = courseFixture2.createCourse(instructor);
+
+        CourseResponseDto responseDto1 = courseFixture.toResponseDto(1L, instructor.getName());
+        CourseResponseDto responseDto3 = courseFixture.toResponseDto(3L, instructor.getName());
+
+        when(courseRepository.findByInstructor_Id(1L)).thenReturn(List.of(course1, course2));
+        when(courseMapper.toResponseDto(course1)).thenReturn(responseDto1);
+        when(courseMapper.toResponseDto(course2)).thenReturn(responseDto3);
+
+        // when
+        List<CourseResponseDto> courses = courseService.getAllCourses(1L);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(courses).hasSize(2);
+            softly.assertThat(courses.get(0).getCourseTitle()).isEqualTo(courseFixture.getCourseTitle());
+            softly.assertThat(courses.get(1).getCourseTitle()).isEqualTo(courseFixture.getCourseTitle());
+        });
+        verify(courseRepository, times(1)).findByInstructor_Id(1L);
+    }
+}

--- a/lms/src/test/java/com/example/lms/domain/course/service/CourseServiceTest.java
+++ b/lms/src/test/java/com/example/lms/domain/course/service/CourseServiceTest.java
@@ -1,0 +1,144 @@
+package com.example.lms.domain.course.service;
+
+
+import com.example.lms.common.fixture.CourseFixture;
+import com.example.lms.common.fixture.InstructorFixture;
+import com.example.lms.domain.course.dto.request.CourseCreateRequestDto;
+import com.example.lms.domain.course.dto.response.CourseResponseDto;
+import com.example.lms.domain.course.entity.Course;
+import com.example.lms.domain.course.mapper.CourseMapper;
+import com.example.lms.domain.course.repository.CourseRepository;
+import com.example.lms.domain.instructor.entity.Instructor;
+import com.example.lms.domain.instructor.repository.InstructorRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CourseServiceTest {
+    @Mock
+    private CourseRepository courseRepository;
+
+    @Mock
+    private InstructorRepository instructorRepository;
+
+    @Mock
+    private CourseMapper courseMapper;
+
+    @InjectMocks
+    private CourseService courseService;
+
+    private Instructor instructor;
+    private Instructor instructor2;
+    private CourseFixture courseFixture;
+    private CourseFixture courseFixture2;
+
+    @BeforeEach
+    void setUp() {
+        instructor = InstructorFixture.INSTRUCTOR_FIXTURE_1.createInstructor();
+        instructor2 = InstructorFixture.INSTRUCTOR_FIXTURE_2.createInstructor();
+        courseFixture = CourseFixture.COURSE_FIXTURE_1;
+        courseFixture2 = CourseFixture.COURSE_FIXTURE_2;
+    }
+
+    @Test
+    @DisplayName("강의를 생성할 때 올바른 엔티티가 저장되고 응답 객체가 반환됩니다.")
+    void createCourse_success() {
+        // given
+        CourseCreateRequestDto requestDto = courseFixture.toCreateRequestDto(1L);
+        Course course = courseFixture.createCourse(instructor);
+        CourseResponseDto responseDto = courseFixture.toResponseDto(1L, instructor.getName());
+
+        when(instructorRepository.findById(1L)).thenReturn(Optional.of(instructor));
+        when(courseMapper.toEntity(requestDto, instructor)).thenReturn(course);
+        when(courseRepository.save(course)).thenReturn(course);
+        when(courseMapper.toResponseDto(course)).thenReturn(responseDto);
+
+        // when
+        CourseResponseDto result = courseService.createCourse(requestDto);
+
+        // then
+        assertThat(result.getCourseTitle()).isEqualTo(courseFixture.getCourseTitle());
+        assertThat(result.getCourseStudents()).isEqualTo(0);
+        assertThat(result.getStartDate()).isEqualTo(courseFixture.getStartDate());
+        assertThat(result.getEndDate()).isEqualTo(courseFixture.getEndDate());
+        assertThat(result.getCourseDescription()).isEqualTo(courseFixture.getCourseDescription());
+        assertThat(result.getInstructorName()).isEqualTo(instructor.getName());
+        verify(courseRepository, times(1)).save(course);
+    }
+
+    @Test
+    @DisplayName("강사가 존재하지 않을 때 예외를 발생시킵니다.")
+    void createCourse_instructorNotFound_throwsException() {
+        // given
+        CourseCreateRequestDto requestDto = courseFixture.toCreateRequestDto(1L);
+        when(instructorRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> courseService.createCourse(requestDto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("존재하지 않는 강사입니다.");
+        verify(courseRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("모든 강의 리스트를 조회할 수 있습니다.")
+    void getAllCourses_success() {
+        // given
+        Course course1 = courseFixture.createCourse(instructor);
+        Course course2 = courseFixture2.createCourse(instructor2);
+
+        CourseResponseDto responseDto1 = courseFixture.toResponseDto(1L, instructor.getName());
+        CourseResponseDto responseDto2 = courseFixture2.toResponseDto(2L, instructor2.getName());
+
+        when(courseRepository.findAll()).thenReturn(List.of(course1, course2));
+        when(courseMapper.toResponseDto(course1)).thenReturn(responseDto1);
+        when(courseMapper.toResponseDto(course2)).thenReturn(responseDto2);
+
+        // when
+        List<CourseResponseDto> courses = courseService.getAllCourses(null);
+
+        // then
+        assertThat(courses).hasSize(2);
+        assertThat(courses.get(0).getCourseTitle()).isEqualTo(courseFixture.getCourseTitle());
+        assertThat(courses.get(1).getCourseTitle()).isEqualTo(courseFixture2.getCourseTitle());
+        assertThat(courses.get(0).getInstructorName()).isEqualTo(instructor.getName());
+        assertThat(courses.get(1).getInstructorName()).isEqualTo(instructor2.getName());
+        verify(courseRepository, times(1)).findAll();
+    }
+
+    @Test
+    @DisplayName("특정 강사의 강의 리스트를 조회할 수 있습니다.")
+    void getAllCoursesByInstructor_success() {
+        // given
+        Course course1 = courseFixture.createCourse(instructor);
+        Course course2 = courseFixture2.createCourse(instructor);
+
+        CourseResponseDto responseDto1 = courseFixture.toResponseDto(1L, instructor.getName());
+        CourseResponseDto responseDto3 = courseFixture.toResponseDto(3L, instructor.getName());
+
+        when(courseRepository.findByInstructor_Id(1L)).thenReturn(List.of(course1, course2));
+        when(courseMapper.toResponseDto(course1)).thenReturn(responseDto1);
+        when(courseMapper.toResponseDto(course2)).thenReturn(responseDto3);
+
+        // when
+        List<CourseResponseDto> courses = courseService.getAllCourses(1L);
+
+        // then
+        assertThat(courses).hasSize(2);
+        assertThat(courses.get(0).getCourseTitle()).isEqualTo(courseFixture.getCourseTitle());
+        assertThat(courses.get(1).getCourseTitle()).isEqualTo(courseFixture.getCourseTitle());
+        verify(courseRepository, times(1)).findByInstructor_Id(1L);
+    }
+}


### PR DESCRIPTION
## Summary

>- #1 

**course, lecture, content 엔티티 추가 및 course 엔티티, 서비스 레이어 작업 및 테스트**

## Tasks

- `Course` 엔티티에 `Lecture` 및 `Content`와의 관계 설정 추가
- `Instructor`와 `Course` 간 `@ManyToOne` 관계 설정
  - 강좌 생성 시 강사의 ID를 기반으로 연관 관계 설정
  - `instructorId`를 `Course` 엔티티 필드에 연결하여 강의 생성 및 조회 기능 구현
- `Course.of()` 정적 팩토리 메서드 추가
  - `Course` 객체 생성을 위한 빌더 패턴을 사용한 정적 팩토리 메서드 추가
  - 메서드명 `of()`를 통해 코드의 가독성 및 객체 생성 방식 개선
- `CourseRequestDto`, `CourseResponseDto` 생성 및 Mapper 구현
  - `MapStruct`를 사용하여 `Entity <-> DTO` 변환 로직 작성
  - `toEntity()`, `toResponseDto()` 메서드를 통해 변환 처리
  - 테스트 코드 작성: `CourseMapperTest`로 매핑 기능 검증
- `CourseRepository` 생성 및 `Service` 계층 구현
  - 강좌 생성 및 전체 강의 조회 기능 추가
  - 특정 강사에 대한 강의 조회 기능 추가 (`getAllCourses(Long instructorId)` 메서드)
  - 테스트 코드 작성:
    - `CourseServiceTest`: 강좌 생성 및 조회 관련 테스트 케이스 작성
    - `CourseFixture`를 사용하여 테스트 데이터 일관성 유지 및 중복 제거
- `build.gradle` 의존성 추가 (`chore`)
  - **MapStruct** 의존성 추가
  - 테스트 환경에서도 **Lombok** 기능을 사용할 수 있도록 설정 추가:
```gradle
// build.gradle
dependencies {
    implementation 'org.mapstruct:mapstruct:1.6.3'
    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'

    testCompileOnly 'org.projectlombok:lombok'
    testAnnotationProcessor 'org.projectlombok:lombok'
}
```
---
## To Reviewer

- 일단은 예전 경험에 따라서 Service에서 Response Dto 생성 후 Controller에서 반환하는 것으로 구현하였는데, Service에서 Response Dto가 아닌 도메인 자체를 넘기는 방식도 있다고 하는데 현재 프로젝트에는 어떤 것이 적합하다고 판단하시는지 궁금합니다!🤨
- 커밋 메세지에 이슈 번호를 기입하지 않은 경우도 있어서 다음 부터는 유의하고 진행하겠습니다 🥲
- 부족한 부분에 대해서 조언 부탁드립니다!😃

## Screenshot

![스크린샷 2025-01-15 오후 3 17 47](https://github.com/user-attachments/assets/565bfda8-d56f-4faa-b61a-dfee588f3f88)
![스크린샷 2025-01-15 오후 3 17 33](https://github.com/user-attachments/assets/2067f2dd-d3e1-4d31-aeff-d5c54dffe6a7)

