### PR TITLE
merge: develop <- feature/quiz-domain #2

### DIFF
--- a/lms/src/main/java/com/example/lms/domain/quiz/dto/QuizRequest.java
+++ b/lms/src/main/java/com/example/lms/domain/quiz/dto/QuizRequest.java
@@ -1,5 +1,6 @@
 package com.example.lms.domain.quiz.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,17 +14,30 @@ import java.util.List;
 @NoArgsConstructor
 public class QuizRequest {
 
+    @Schema(description = "퀴즈 제목", example = "수도 퀴즈")
     private String quizTitle;
+
+    @Schema(description = "과정 ID", example = "1")
     private Long courseId;
+
+    @Schema(description = "퀴즈 마감일", example = "2025-01-24T18:00:00")
     private LocalDateTime quizDueDate;
+
+    @Schema(description = "퀴즈 질문 목록")
     private List<QuestionRequest> questions;
 
     @Getter
     @Setter
     @NoArgsConstructor
     public static class QuestionRequest {
+
+        @Schema(description = "질문 내용", example = "대한민국의 수도는 어디인가요?")
         private String content;
+
+        @Schema(description = "정답", example = "서울")
         private String correct;
+
+        @Schema(description = "배점", example = "10")
         private Integer point;
     }
 }

--- a/lms/src/main/java/com/example/lms/domain/quiz/dto/QuizSubmissionRequest.java
+++ b/lms/src/main/java/com/example/lms/domain/quiz/dto/QuizSubmissionRequest.java
@@ -1,5 +1,6 @@
 package com.example.lms.domain.quiz.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,13 @@ import java.util.Map;
 @Getter
 @NoArgsConstructor
 public class QuizSubmissionRequest {
+    @Schema(description = "학생 ID", example = "1")
     private Long studentId;
+
+    @Schema(
+            description = "퀴즈 답변 목록",
+            example = "{\"1\": \"Answer1\", \"2\": \"Answer2\"}"
+    )
     private Map<Long, String> answers;
 
     public void setStudentId(Long studentId) {

--- a/lms/src/main/java/com/example/lms/domain/quiz/service/QuizSubmissionService.java
+++ b/lms/src/main/java/com/example/lms/domain/quiz/service/QuizSubmissionService.java
@@ -47,6 +47,10 @@ public class QuizSubmissionService {
             Question question = questionRepository.findById(questionId)
                     .orElseThrow(() -> new IllegalArgumentException("문제를 찾을 수 없습니다."));
 
+            if (!question.getQuiz().getId().equals(quizId)) {
+                throw new IllegalArgumentException("질문이 해당 퀴즈에 속하지 않습니다.");
+            }
+
             boolean isCorrect = question.getCorrect().equals(submittedAnswer);
             totalPoints += question.getPoint();
             if (isCorrect) {
@@ -57,7 +61,7 @@ public class QuizSubmissionService {
             answerRepository.save(answer);
         }
 
-            int grade = (correctPoints * 100) / totalPoints;
+            int grade = totalPoints > 0 ? (correctPoints * 100) / totalPoints : 0;
             QuizGrade quizGrade = QuizGrade.create(student, quiz, grade);
             quizGradeRepository.save(quizGrade);
 


### PR DESCRIPTION
## Summary

>- #2 

- Dto에 스키마 설명 및 예제 값 추가
- totalPoints가 0일 경우 처리 로직 추가

## Tasks

- Dto에 스키마 설명 및 예제 값 추가 -> swagger에서 좀 더 편하게 테스트할 수 있도록 수정했습니다.
- totalPoints가 0일 때 발생할 수 있는 예외를 방지하기 위해 if문에 조건 추가

## To Reviewer

_추가하거나 수정해야할 부분 있으면 피드백주세요!_

_퀴즈 성적 테스트를 해보다가 약간의 고민(?)이 생겼는데 지금 구현해놓은 상태로는 학생이 퀴즈 답안을 제출하면 성공적으로 제출되었다는 메시지와 함께 각 퀴즈 ID에 따른 totalPoints와 correctPoints가 나오고 백분율로 계산하여 성적(grade)이 저장됩니다. 이 grade를 지금처럼 각 퀴즈 ID(quiz_id)에 대한 성적으로 저장하는 것 아니면 과정 ID(course_id)의 여러 퀴즈에 대한 전체 성적으로 저장하는 것이 고민인데 어느 방향이 더 좋을것 같은지 의견 남겨주시면 감사드리겠습니다 !_

## Screenshot
<img width="1402" alt="스크린샷 2025-01-21 오후 1 10 40" src="https://github.com/user-attachments/assets/c7a4bce8-0e60-4d40-a73e-41096444e8ae" />
<img width="1408" alt="스크린샷 2025-01-21 오후 1 11 29" src="https://github.com/user-attachments/assets/0855f89f-6977-4f3a-ba66-4d50cdad67c2" />
<img width="267" alt="스크린샷 2025-01-21 오후 1 11 40" src="https://github.com/user-attachments/assets/250817ec-24ba-4b12-90b2-c7b676bd69eb" />

_학생이 퀴즈 답안을 제출하는 스크린샷과 grade 테이블에 데이터베이스가 저장되는 스크린샷 첨부했습니다._
